### PR TITLE
fix: add missing model parameter in usage reporting #3

### DIFF
--- a/api/src/main/java/com/ke/bella/batch/api/QueueController.java
+++ b/api/src/main/java/com/ke/bella/batch/api/QueueController.java
@@ -71,6 +71,9 @@ public class QueueController {
         Assert.notNull(put.getEndpoint(), "endpoint cannot be null");
         Assert.notNull(put.getData(), "data cannot be null");
 
+        String model = MapUtils.getString(put.getData(), "model");
+        Assert.hasText(model, "model parameter is required in request data");
+
         Task task = qs.put(put);
 
         if(ResponseMode.blocking.name().equals(put.getResponseMode())) {

--- a/api/src/main/java/com/ke/bella/batch/service/QueueService.java
+++ b/api/src/main/java/com/ke/bella/batch/service/QueueService.java
@@ -257,6 +257,7 @@ public class QueueService {
                 .akCode(apikeyInfo.getCode())
                 .apikey(apikeyInfo.getApikey())
                 .akSha(apikeyInfo.getAkSha())
+                .model(MapUtils.getString(task.getData(), "model"))
                 .channelCode(channel.getChannelCode())
                 .priceInfo(channel.getPriceInfo())
                 .requestId(task.getTaskId())


### PR DESCRIPTION
1. 修复上报计费缺少model参数的问题

遗留
1. 感觉之前参数校验都散落在各层，不是很规范
2. 当前实现对照OpenapiUtils的route，个人感觉有点问题（强绑model字段），理论上不一定queue需要model。