### PR TITLE
fix: 修复任务查询接口 result 字段 JSON 双重转义问题

### DIFF
--- a/api/src/main/java/com/ke/bella/batch/db/repo/QueueRepo.java
+++ b/api/src/main/java/com/ke/bella/batch/db/repo/QueueRepo.java
@@ -410,9 +410,9 @@ public class QueueRepo implements BaseRepo {
                 fetchStringFromFile(queueDB.getInputFileId()), Map.class);
     }
 
-    private String parseOutputData(QueueDB queueDB) {
+    private Object parseOutputData(QueueDB queueDB) {
         return parseData(queueDB.getOutputData(),
-                fetchStringFromFile(queueDB.getOutputFileId()), String.class);
+                fetchStringFromFile(queueDB.getOutputFileId()), Object.class);
     }
 
     private <T> T parseData(String originData, String fileData, Class<T> clazz) {


### PR DESCRIPTION
## Summary
- 修复 `/v1/queue/{taskId}` 接口返回的 `result` 字段被双重 JSON 转义的问题
- `parseOutputData` 返回类型从 `String` 改为 `Object`，解析类型从 `String.class` 改为 `Object.class`
- 使用 `Object.class` 而非 `Map.class`，兼容 JSON 对象和数组等多种格式

## 原因
`parseOutputData` 原先返回 `String`，Jackson 序列化时将其当作字符串字面量输出，导致 `result` 字段变成转义的 JSON 字符串（如 `"{\"status_code\":200,...}"`），而非 JSON 对象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)